### PR TITLE
Remove notes to avoid MAX_ITEMS error

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -66,10 +66,10 @@ function onDoneEditingMovieNote(event)
         noteText = defaultNote;
         // if edit box is empty, remove any existing note from storage
         removeNote(title);
-	} else {
+    } else {
         // Save the note
         saveNote(title, noteText);
-	}
+    }
 
     // Replace the edit box with a regular <span> of text
     setNoteText(elem, noteText);

--- a/contentscript.js
+++ b/contentscript.js
@@ -64,11 +64,11 @@ function onDoneEditingMovieNote(event)
     var noteText = elem.value.replace(/&/g, '&amp;').replace(/</g, '&lt;');
     if (noteText == '') {
         noteText = defaultNote;
-		// if edit box is empty, remove any existing note from storage
-		removeNote(title);
+        // if edit box is empty, remove any existing note from storage
+        removeNote(title);
 	} else {
-		// Save the note
-		saveNote(title, noteText);
+        // Save the note
+        saveNote(title, noteText);
 	}
 
     // Replace the edit box with a regular <span> of text
@@ -121,7 +121,7 @@ function loadNotes(movies)
 // remove any existing note for the title
 function removeNote(movieTitle)
 {
-	chrome.storage.sync.remove(movieTitle);
+    chrome.storage.sync.remove(movieTitle);
 }
 
 function saveNote(movieTitle, note)

--- a/contentscript.js
+++ b/contentscript.js
@@ -62,11 +62,14 @@ function onDoneEditingMovieNote(event)
     }
 
     var noteText = elem.value.replace(/&/g, '&amp;').replace(/</g, '&lt;');
-    if (noteText == '')
+    if (noteText == '') {
         noteText = defaultNote;
-
-    // Save the note
-    saveNote(title, noteText);
+		// if edit box is empty, remove any existing note from storage
+		removeNote(title);
+	} else {
+		// Save the note
+		saveNote(title, noteText);
+	}
 
     // Replace the edit box with a regular <span> of text
     setNoteText(elem, noteText);
@@ -113,6 +116,12 @@ function loadNotes(movies)
             setNoteText(movies[movieTitle], movieNote);
         }
     });
+}
+
+// remove any existing note for the title
+function removeNote(movieTitle)
+{
+	chrome.storage.sync.remove(movieTitle);
 }
 
 function saveNote(movieTitle, note)


### PR DESCRIPTION
The current version of netflix-notes is fantastic but never removes notes. The maximum amount of items an extension can place into Chrome sync storage is 512 items--attempting to add any further items will result in a MAX_ITEMS error. As a result, when you've used Netflix Notes for some time and entered small notes for 512 films at various times over the years, attempting to add any further notes will fail with a MAX_ITEMS error, and the extension becomes unusable. The only fix I've determined is to uninstall and reinstall the extension, which loses all existing notes.

With this change, if you are editing an existing note and you remove all text, the note for the film is removed from storage. The original version would update the existing note to be "add note" instead of removing the existing note. With the ability to remove existing notes, you can keep your note count well under 512. 

I ran into this issue because I stick a small notation for family-friendliness or non-family-friendliness on films that are in my queue (which is amazingly useful, thanks so much for developing the extension!), and after quite a long time, I hit the MAX_ITEMS limit since old notes never get removed.
